### PR TITLE
fix(magichome): исправлена ошибка типов int - string в cycle_magichome

### DIFF
--- a/modules/magichome/magichome.class.php
+++ b/modules/magichome/magichome.class.php
@@ -383,11 +383,11 @@ $enable=$cmd_rec['VALUE'];
 
 $enable=1;
 $cmd_rec = SQLSelectOne("SELECT VALUE FROM magichome_config where parametr='EVERY'");
-$every=$cmd_rec['VALUE'];
+$every = isset($cmd_rec['VALUE']) ? (int)$cmd_rec['VALUE'] : 60;
 
 
 $cmd_rec = SQLSelectOne("SELECT VALUE FROM magichome_config where parametr='LASTCYCLE_TS'");
-$latest=$cmd_rec['VALUE'];
+$latest = isset($cmd_rec['VALUE']) ? (int)$cmd_rec['VALUE'] : 0;
 
    $tdev = time()-$latest;
    $has = $tdev>$every*60;


### PR DESCRIPTION

## Исправление ошибки в cycle_magichome### ПроблемаЦикл `cycle_magichome` падал с ошибкой:
PHP exception (code 0): Unsupported operand types: int - string
in /var/www/modules/magichome/magichome.class.php on line 392
### Причина- Переменные `$every` и `$latest` получались из базы данных как строки- При выполнении арифметических операций (`time() - $latest`, `$tdev > $every * 60`) происходило неявное преобразование типов, что вызывало ошибку в PHP 8+### Решение1. **Строка 386**: Добавлена проверка `isset()` и явное приведение к `(int)` для переменной `$every` с значением по умолчанию `60`2. **Строка 390**: Добавлена проверка `isset()` и явное приведение к `(int)` для переменной `$latest` с значением по умолчанию `0`### Измененные файлы- `modules/magichome/magichome.class.php`### Изменения// Было:$every = $cmd_rec['VALUE'];$latest = $cmd_rec['VALUE'];// Стало:$every = isset($cmd_rec['VALUE']) ? (int)$cmd_rec['VALUE'] : 60;$latest = isset($cmd_rec['VALUE']) ? (int)$cmd_rec['VALUE'] : 0;